### PR TITLE
docs(DEVPL-4374): folderId on List Assets endpoint

### DIFF
--- a/openapi/v2.yml
+++ b/openapi/v2.yml
@@ -41944,6 +41944,18 @@ paths:
           required: false
           schema:
             type: integer
+        - in: query
+          allowEmptyValue: true
+          name: folderId
+          example: 6258612d1ee792848f805dcf
+          description: |
+            Optional asset folder ID. When provided, results are filtered to
+            assets within the folder *and all of its descendant folders*. The
+            `pagination.total` reflects the filtered count.
+          required: false
+          schema:
+            type: string
+            format: objectid
       responses:
         '200':
           description: Request was successful
@@ -41980,6 +41992,7 @@ paths:
                             quality: 100
                             error: null
                         altText: A single candy wrapper
+                        folderId: 6258612d1ee792848f805dcf
                       required:
                         - id
                         - contentType
@@ -41992,6 +42005,7 @@ paths:
                         - createdOn
                         - variants
                         - altText
+                        - folderId
                       properties:
                         id:
                           type: string
@@ -42094,6 +42108,15 @@ paths:
                           example: A red chair
                           nullable: true
                           description: The visual description of the asset
+                        folderId:
+                          type: string
+                          format: objectid
+                          example: 6258612d1ee792848f805dcf
+                          nullable: true
+                          description: |
+                            The ID of the asset folder this asset belongs to,
+                            or `null` if the asset is not in any folder.
+                          readOnly: true
                   pagination:
                     description: Pagination object
                     type: object
@@ -42138,6 +42161,7 @@ paths:
                           quality: 100
                           error: null
                       altText: A single candy wrapper
+                      folderId: 6258612d1ee792848f805dcf
                     - id: 63e5889e7fe4eafa7384cea5
                       originalFileName: Gum-Wrapper.svg
                       displayName: 63e5889e7fe4eafa7384cea5_Gum-Wrapper.png
@@ -42157,6 +42181,7 @@ paths:
                           quality: 100
                           error: null
                       altText: A single gum wrapper
+                      folderId: null
                   pagination:
                     total: 2
                     offset: 0


### PR DESCRIPTION
JIRA: https://webflow.atlassian.net/browse/DEVPL-4374
Monorepo PR: https://github.com/webflow/webflow/pull/106195

## Summary

Documents the new `folderId` query parameter and `folderId` response field for the `list-assets` operation.

When `folderId` is provided, the endpoint returns assets within that folder **and all of its descendant folders**, with `pagination.total` reflecting the filtered count. Each asset in the response includes a `folderId` field (nullable string, ObjectId format) indicating which folder the asset belongs to (or `null` if it isn't in any folder).

## Notes

- Paired with the monorepo implementation in webflow/webflow#106195 — the spec should land when (or shortly after) that PR ships.
- Scoped to `list-assets`. The runtime change keeps `folderId` strictly on the list-assets surface; `get-asset`, `patch-asset`, and upload responses are unchanged. Adding folder context there would need a separate, deliberate spec change.
- No new permission scopes (`assets:read` continues to govern access).
- Backward compatible (omitting `folderId` is unchanged from today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)